### PR TITLE
Add detailed weather forecast page with unit toggle

### DIFF
--- a/weather-app/app.js
+++ b/weather-app/app.js
@@ -187,11 +187,15 @@ function renderTable() {
     const g = weatherGroup(entry.data.current_weather.weathercode);
     iconBox.appendChild(fallbackIcon(g));
 
-    const bar = document.createElement("div"); bar.className = "wx-headbar"; bar.textContent = placeText(entry.loc);
+    const bar = document.createElement("div"); bar.className = "wx-headbar";
+    const link = document.createElement("a");
+    link.href = `details.html?lat=${entry.loc.latitude}&lon=${entry.loc.longitude}&place=${encodeURIComponent(placeText(entry.loc))}`;
+    link.textContent = placeText(entry.loc);
+    link.title = `View detailed forecast for ${placeText(entry.loc)}`;
     const btn = document.createElement("button"); btn.className = "remove"; btn.title = "Remove";
     btn.setAttribute("aria-label", `Remove ${placeText(entry.loc)} from comparison`);
     btn.textContent = "×"; btn.addEventListener("click", () => removeFromCompare(entry.key));
-    bar.appendChild(btn);
+    bar.append(link, btn);
 
     wrap.append(iconBox, bar);
     return wrap;

--- a/weather-app/details.html
+++ b/weather-app/details.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Weather Details</title>
+
+  <!-- Roboto font -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="style.css?v=11" />
+</head>
+<body>
+  <main class="container">
+    <h1 id="title">Weather Details</h1>
+    <button id="unit-toggle" type="button">Show °F</button>
+
+    <section>
+      <h2>5-day forecast</h2>
+      <table id="daily-table"></table>
+    </section>
+
+    <section>
+      <h2>Next 24 hours</h2>
+      <table id="hourly-table"></table>
+    </section>
+  </main>
+
+  <script src="details.js?v=11"></script>
+</body>
+</html>

--- a/weather-app/details.js
+++ b/weather-app/details.js
@@ -1,0 +1,71 @@
+const params = new URLSearchParams(location.search);
+const lat = parseFloat(params.get('lat'));
+const lon = parseFloat(params.get('lon'));
+const place = params.get('place') || 'Location';
+
+const titleEl = document.getElementById('title');
+const dailyTable = document.getElementById('daily-table');
+const hourlyTable = document.getElementById('hourly-table');
+const toggleBtn = document.getElementById('unit-toggle');
+
+let unit = 'C';
+let weatherData = null;
+
+titleEl.textContent = `Weather details for ${place}`;
+
+function formatTemp(c) {
+  return unit === 'C' ? `${Math.round(c)}°C` : `${Math.round(c * 9 / 5 + 32)}°F`;
+}
+
+function dirText(deg) {
+  const dirs = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  return dirs[Math.round(deg / 45) % 8];
+}
+
+function renderDaily() {
+  const d = weatherData.daily;
+  let html = '<tr><th>Date</th><th>Min</th><th>Max</th><th>Rain (mm)</th><th>Wind (km/h)</th><th>Dir</th></tr>';
+  for (let i = 0; i < d.time.length; i++) {
+    html += `<tr><td>${d.time[i]}</td><td>${formatTemp(d.temperature_2m_min[i])}</td><td>${formatTemp(d.temperature_2m_max[i])}</td><td>${Math.round(d.precipitation_sum[i] * 10) / 10}</td><td>${Math.round(d.windspeed_10m_max[i])}</td><td>${dirText(d.winddirection_10m_dominant[i])}</td></tr>`;
+  }
+  dailyTable.innerHTML = html;
+}
+
+function renderHourly() {
+  const h = weatherData.hourly;
+  let html = '<tr><th>Time</th><th>Temp</th><th>Rain (mm)</th><th>Wind (km/h)</th><th>Dir</th></tr>';
+  const now = Date.now();
+  let start = 0;
+  while (start < h.time.length && new Date(h.time[start]).getTime() < now) start++;
+  for (let i = start; i < start + 24 && i < h.time.length; i++) {
+    html += `<tr><td>${h.time[i]}</td><td>${formatTemp(h.temperature_2m[i])}</td><td>${Math.round(h.precipitation[i] * 10) / 10}</td><td>${Math.round(h.windspeed_10m[i])}</td><td>${dirText(h.winddirection_10m[i])}</td></tr>`;
+  }
+  hourlyTable.innerHTML = html;
+}
+
+function render() {
+  renderDaily();
+  renderHourly();
+  toggleBtn.textContent = unit === 'C' ? 'Show °F' : 'Show °C';
+}
+
+toggleBtn.addEventListener('click', () => {
+  unit = unit === 'C' ? 'F' : 'C';
+  render();
+});
+
+async function fetchDetails() {
+  const qs = new URLSearchParams({
+    latitude: lat,
+    longitude: lon,
+    timezone: 'auto',
+    daily: 'temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max,winddirection_10m_dominant',
+    hourly: 'temperature_2m,precipitation,windspeed_10m,winddirection_10m',
+    forecast_days: '5'
+  });
+  const res = await fetch(`https://api.open-meteo.com/v1/forecast?${qs.toString()}`);
+  weatherData = await res.json();
+  render();
+}
+
+fetchDetails();

--- a/weather-app/style.css
+++ b/weather-app/style.css
@@ -53,6 +53,7 @@ button { padding: 10px 14px; border: 0; border-radius: var(--radius); background
   display: flex; align-items: center; justify-content: space-between;
   gap: 10px; padding: 8px 12px; font-weight: 700;
 }
+.wx-headbar a { flex: 1; color: inherit; text-decoration: none; }
 .remove {
   display: flex;
   align-items: center;
@@ -68,6 +69,9 @@ button { padding: 10px 14px; border: 0; border-radius: var(--radius); background
 
 /* Fallback SVG size */
 .wx-fallback { width: 56px; height: 56px; }
+
+table { width: 100%; border-collapse: collapse; margin: 12px 0; }
+th, td { border: 1px solid var(--border); padding: 8px; text-align: left; }
 
 /* Responsive */
 @media (max-width: 980px) { .wx-table { grid-template-columns: 140px repeat(var(--cols), 1fr); } }


### PR DESCRIPTION
## Summary
- Link each compared location to a new detailed forecast page.
- Show 5‑day and hourly forecasts with rain and wind data.
- Allow toggling between Celsius and Fahrenheit units.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check weather-app/details.js`
- `node --check weather-app/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aabe01ea4c83218c168b0db0731b66