### PR TITLE
Show weather details as interactive charts

### DIFF
--- a/weather-app/details.html
+++ b/weather-app/details.html
@@ -19,15 +19,16 @@
 
     <section>
       <h2>5-day forecast</h2>
-      <table id="daily-table"></table>
+      <canvas id="daily-chart" style="height:300px"></canvas>
     </section>
 
     <section>
       <h2>Next 24 hours</h2>
-      <table id="hourly-table"></table>
+      <canvas id="hourly-chart" style="height:300px"></canvas>
     </section>
   </main>
 
-  <script src="details.js?v=11"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="details.js?v=12"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace static forecast tables with Chart.js canvases
- Render 5-day and 24-hour forecasts as interactive line charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abaed8b2d8832193363396a9ef2f32