### PR TITLE
Fix chart height expanding on load

### DIFF
--- a/weather-app/details.html
+++ b/weather-app/details.html
@@ -19,12 +19,12 @@
 
     <section>
       <h2>5-day forecast</h2>
-      <canvas id="daily-chart" style="height:300px"></canvas>
+      <canvas id="daily-chart" height="150" style="height:150px"></canvas>
     </section>
 
     <section>
       <h2>Next 24 hours</h2>
-      <canvas id="hourly-chart" style="height:300px"></canvas>
+      <canvas id="hourly-chart" height="150" style="height:150px"></canvas>
     </section>
   </main>
 

--- a/weather-app/details.js
+++ b/weather-app/details.js
@@ -6,6 +6,10 @@ const place = params.get('place') || 'Location';
 const titleEl = document.getElementById('title');
 const dailyCanvas = document.getElementById('daily-chart');
 const hourlyCanvas = document.getElementById('hourly-chart');
+
+// Fix chart height so it doesn't grow on load
+dailyCanvas.height = 150;
+hourlyCanvas.height = 150;
 const toggleBtn = document.getElementById('unit-toggle');
 
 let unit = 'C';


### PR DESCRIPTION
## Summary
- Fix weather details charts growing vertically by explicitly setting canvas height to 150px
- Ensure chart canvases are initialized with fixed height to prevent expansion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abb033b1bc8321a743bbcb48a6afd5