### PR TITLE
Add Xero plan selection UI mockup

### DIFF
--- a/Xero UI/index.html
+++ b/Xero UI/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Xero Plan UI</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="breadcrumb">
+    <span class="current">Plan</span>
+    <span>Add-ons</span>
+    <span>Select billing account</span>
+    <span>Review &amp; pay</span>
+  </header>
+
+  <h1>Change plan for KC - Experiment test</h1>
+
+  <main class="main">
+    <section class="plans">
+      <h2>Your plan</h2>
+      <div class="plan-grid">
+        <div class="plan-card">
+          <h3>Ignite</h3>
+          <p class="price">$35<span>/month</span></p>
+          <ul class="features">
+            <li class="available">Reconcile bank transactions</li>
+            <li class="available">Send invoices and quotes</li>
+            <li class="available">Enter bills</li>
+            <li class="unavailable">Claim expenses</li>
+            <li class="unavailable">Projects</li>
+            <li class="available">Payroll for 1 person</li>
+          </ul>
+          <button>Select</button>
+        </div>
+        <div class="plan-card">
+          <h3>Go</h3>
+          <p class="price">$52<span>/month</span></p>
+          <ul class="features">
+            <li class="available">Reconcile bank transactions</li>
+            <li class="available">Send invoices and quotes</li>
+            <li class="available">Enter bills</li>
+            <li class="unavailable">Claim expenses</li>
+            <li class="unavailable">Projects</li>
+            <li class="available">Payroll for 2 people</li>
+          </ul>
+          <button>Select</button>
+        </div>
+        <div class="plan-card">
+          <h3>Comprehensive</h3>
+          <p class="price">$78<span>/month</span></p>
+          <ul class="features">
+            <li class="available">Reconcile bank transactions</li>
+            <li class="available">Send invoices and quotes</li>
+            <li class="available">Enter bills</li>
+            <li class="available">Claim expenses</li>
+            <li class="available">Projects</li>
+            <li class="available">Payroll for 5 people</li>
+          </ul>
+          <button>Select</button>
+        </div>
+        <div class="plan-card">
+          <h3>Ultimate</h3>
+          <p class="price">$130<span>/month</span></p>
+          <ul class="features">
+            <li class="available">Reconcile bank transactions</li>
+            <li class="available">Send invoices and quotes</li>
+            <li class="available">Enter bills</li>
+            <li class="available">Claim expenses</li>
+            <li class="available">Projects</li>
+            <li class="available">Payroll for 200 people</li>
+          </ul>
+          <button>Select</button>
+        </div>
+      </div>
+      <p class="disclaimer">Prices in AUD including GST.</p>
+      <p class="disclaimer">50% discount applied for first three months.</p>
+    </section>
+
+    <aside class="summary">
+      <h2>Plan summary</h2>
+      <div class="summary-item">
+        <span>Comprehensive</span>
+        <span>$100.00</span>
+      </div>
+      <div class="summary-item">
+        <span class="addon">Analytics Plus</span>
+        <span>$9.00</span>
+      </div>
+      <div class="summary-item">
+        <span class="addon">Expenses</span>
+        <span>$7.00</span>
+      </div>
+      <div class="summary-item total">
+        <span>Recurring monthly amount</span>
+        <span>$88.00</span>
+      </div>
+      <button class="continue">Continue to add-ons</button>
+    </aside>
+  </main>
+</body>
+</html>

--- a/Xero UI/style.css
+++ b/Xero UI/style.css
@@ -1,0 +1,157 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f7fa;
+  margin: 0;
+  padding: 0;
+  color: #222;
+}
+
+.breadcrumb {
+  background: #fff;
+  display: flex;
+  padding: 10px 20px;
+  gap: 20px;
+  border-bottom: 1px solid #ccc;
+  font-size: 14px;
+}
+
+.breadcrumb span {
+  color: #888;
+}
+
+.breadcrumb .current {
+  color: #000;
+  font-weight: bold;
+}
+
+h1 {
+  padding: 20px;
+  margin: 0;
+  font-size: 24px;
+}
+
+.main {
+  display: flex;
+  align-items: flex-start;
+  padding: 0 20px 40px;
+  gap: 20px;
+}
+
+.plans {
+  flex: 1;
+}
+
+.plan-grid {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.plan-card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  flex: 1;
+  min-width: 200px;
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+}
+
+.plan-card h3 {
+  margin-top: 0;
+}
+
+.plan-card .price {
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.plan-card .price span {
+  font-size: 14px;
+  font-weight: normal;
+}
+
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0;
+  flex: 1;
+}
+
+.features li {
+  margin-bottom: 6px;
+}
+
+.features li.available::before {
+  content: "\2713";
+  color: #008000;
+  margin-right: 4px;
+}
+
+.features li.unavailable::before {
+  content: "\2715";
+  color: #cc0000;
+  margin-right: 4px;
+}
+
+.plan-card button {
+  background: #0c62fb;
+  color: #fff;
+  padding: 8px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.plan-card button:hover {
+  background: #084ec1;
+}
+
+.disclaimer {
+  font-size: 12px;
+  color: #555;
+  margin-top: 20px;
+}
+
+.summary {
+  width: 300px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 15px;
+}
+
+.summary h2 {
+  margin-top: 0;
+  font-size: 20px;
+}
+
+.summary-item {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #eee;
+  padding: 8px 0;
+  font-size: 14px;
+}
+
+.summary-item.total {
+  font-weight: bold;
+}
+
+.continue {
+  width: 100%;
+  background: #0c62fb;
+  color: #fff;
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.continue:hover {
+  background: #084ec1;
+}


### PR DESCRIPTION
## Summary
- add new `Xero UI` folder with HTML/CSS implementing pricing plan selection and summary sidebar
- include styling for plan cards, feature availability icons, breadcrumbs and summary panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a86cf9d88321b290600bc69b511c