### PR TITLE
Fix datalist weather selection using stored coordinates

### DIFF
--- a/weather-app/index.html
+++ b/weather-app/index.html
@@ -34,6 +34,6 @@
     </section>
   </main>
 
-  <script src="app.js?v=11"></script>
+  <script src="app.js?v=12"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Preserve selected suggestion's coordinates before clearing datalist
- Use stored coordinates on submit to avoid unnecessary geocoding
- Bump weather app script version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6557bbfc08321a8291a5ad574da2f