### PR TITLE
feat: add number-to-text converter web app

### DIFF
--- a/number-to-text/README.md
+++ b/number-to-text/README.md
@@ -1,0 +1,25 @@
+# Number to Text Converter
+
+A single-page web app that converts integers to their written English form in both International and Indian numbering systems.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+### Scripts
+
+- `npm run dev` – start development server
+- `npm run build` – build production bundle
+- `npm run preview` – preview the production build
+- `npm test` – run unit and integration tests
+
+## Features
+
+- Supports 0 – 9,999,999,999
+- International and Indian numbering systems with auto-detect + toggle
+- Validation with accessible error messaging
+- Copy-to-clipboard with toast confirmation
+- Keyboard friendly and screen-reader aware output

--- a/number-to-text/index.html
+++ b/number-to-text/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Number to Text Converter</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body class="bg-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/number-to-text/package.json
+++ b/number-to-text/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "number-to-text",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.2",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^1.6.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "jsdom": "^24.0.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11",
+    "vitest": "^1.6.0"
+  }
+}

--- a/number-to-text/postcss.config.js
+++ b/number-to-text/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/number-to-text/public/favicon.svg
+++ b/number-to-text/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2B59C3" />
+      <stop offset="100%" stop-color="#F2A104" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g)" />
+  <text x="64" y="82" font-family="'Segoe UI', sans-serif" font-size="56" fill="#fff" text-anchor="middle">123</text>
+</svg>

--- a/number-to-text/src/App.test.tsx
+++ b/number-to-text/src/App.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { createRoot, Root } from 'react-dom/client';
+import App from './App';
+
+declare global {
+  interface Navigator {
+    clipboard: { writeText: (value: string) => Promise<void> };
+  }
+}
+
+Object.defineProperty(navigator, 'language', {
+  value: 'en-US',
+  configurable: true
+});
+
+describe('App component', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      configurable: true
+    });
+    act(() => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+  });
+
+  afterEach(() => {
+    writeTextMock.mockClear();
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+  const changeInputValue = (value: string) => {
+    const input = container.querySelector('input#number-input') as HTMLInputElement;
+    act(() => {
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  };
+
+  const clickButton = (name: string) => {
+    const button = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.trim().toLowerCase() === name.toLowerCase()
+    );
+    if (!button) throw new Error(`Button with text ${name} not found`);
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  };
+
+  it('converts input value into words', () => {
+    changeInputValue('1200');
+    clickButton('Convert');
+
+    const result = container.querySelector('[aria-live="polite"]');
+    expect(result?.textContent).toContain('One thousand two hundred');
+  });
+
+  it('validates invalid input', () => {
+    changeInputValue('12 00');
+    clickButton('Convert');
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toMatch(/integers only/i);
+  });
+
+  it('copies the result to clipboard', async () => {
+    changeInputValue('21');
+    clickButton('Convert');
+    clickButton('Copy result');
+
+    expect(writeTextMock).toHaveBeenCalledWith('Twenty one');
+  });
+});

--- a/number-to-text/src/App.tsx
+++ b/number-to-text/src/App.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Toggle from './components/Toggle';
+import Toast from './components/Toast';
+import {
+  MAX_VALUE,
+  NumberingSystem,
+  detectSystemFromLocale,
+  isValidDigitsOnly,
+  loadPersistedSystem,
+  persistSystem,
+  sanitizeNumericInput,
+  sentenceCase
+} from './lib/helpers';
+import { convertNumberToText } from './lib/converter';
+
+const App = () => {
+  const [inputValue, setInputValue] = useState('');
+  const [system, setSystem] = useState<NumberingSystem>('international');
+  const [detectedSystem, setDetectedSystem] = useState<NumberingSystem>('international');
+  const [result, setResult] = useState('');
+  const [error, setError] = useState('');
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+  const lastParsedValue = useRef<number | null>(null);
+
+  useEffect(() => {
+    const persisted = loadPersistedSystem();
+    if (persisted) {
+      setSystem(persisted);
+      setDetectedSystem(persisted);
+      return;
+    }
+    const locale = typeof navigator !== 'undefined' ? navigator.language : undefined;
+    const detected = detectSystemFromLocale(locale);
+    setSystem(detected);
+    setDetectedSystem(detected);
+  }, []);
+
+  const showToast = useCallback((message: string) => {
+    setToastMessage(message);
+    setToastVisible(true);
+  }, []);
+
+  const hideToast = useCallback(() => {
+    setToastVisible(false);
+  }, []);
+
+  const handleSystemChange = useCallback(
+    (value: NumberingSystem) => {
+      setSystem(value);
+      persistSystem(value);
+      if (lastParsedValue.current !== null) {
+        const newResult = convertNumberToText(lastParsedValue.current, value);
+        setResult(newResult);
+      }
+    },
+    []
+  );
+
+  const parseInputValue = useCallback(
+    (value: string): number | null => {
+      const sanitized = sanitizeNumericInput(value);
+      if (sanitized === '') {
+        setError('');
+        return null;
+      }
+      if (!isValidDigitsOnly(sanitized)) {
+        setError('Integers only. Try removing spaces, symbols, or decimals.');
+        return null;
+      }
+      const parsed = Number.parseInt(sanitized, 10);
+      if (Number.isNaN(parsed)) {
+        setError('Integers only. Try removing spaces, symbols, or decimals.');
+        return null;
+      }
+      if (parsed > MAX_VALUE) {
+        setError('Supported range is 0 to 9,999,999,999.');
+        return null;
+      }
+      setError('');
+      return parsed;
+    },
+    []
+  );
+
+  const handleConvert = useCallback(() => {
+    const parsed = parseInputValue(inputValue);
+    if (parsed === null) {
+      setResult('');
+      lastParsedValue.current = null;
+      return;
+    }
+
+    const words = convertNumberToText(parsed, system);
+    lastParsedValue.current = parsed;
+    setResult(words);
+  }, [inputValue, parseInputValue, system]);
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      handleConvert();
+    },
+    [handleConvert]
+  );
+
+  const handleCopy = async () => {
+    if (!result) return;
+    try {
+      if (!('clipboard' in navigator) || typeof navigator.clipboard?.writeText !== 'function') {
+        showToast('Clipboard is unavailable in this browser.');
+        return;
+      }
+      await navigator.clipboard.writeText(result);
+      showToast('Copied to clipboard.');
+    } catch (error) {
+      showToast('Unable to copy. Try again.');
+    }
+  };
+
+  const detectedLabel = useMemo(() => sentenceCase(detectedSystem), [detectedSystem]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-slate-100">
+      <div className="mx-auto flex min-h-screen max-w-4xl flex-col px-4 py-12 sm:px-6 lg:px-8">
+        <header className="mb-12 text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Utility</p>
+          <h1 className="mt-4 text-3xl font-semibold sm:text-4xl">Number to Text Converter</h1>
+          <p className="mt-4 text-base text-slate-300 sm:text-lg">
+            Convert integers up to 9,999,999,999 into clear English words in either International or Indian formats.
+          </p>
+        </header>
+
+        <main className="flex flex-1 flex-col gap-10">
+          <section className="rounded-3xl bg-slate-900/60 p-6 shadow-2xl ring-1 ring-slate-800/60 backdrop-blur">
+            <form onSubmit={onSubmit} className="flex flex-col gap-6">
+              <label htmlFor="number-input" className="flex flex-col gap-2 text-sm font-medium text-slate-200">
+                Enter a number
+                <input
+                  id="number-input"
+                  name="number"
+                  inputMode="numeric"
+                  pattern="[0-9,]*"
+                  placeholder="e.g., 1200"
+                  aria-invalid={Boolean(error)}
+                  value={inputValue}
+                  onChange={(event) => setInputValue(event.target.value)}
+                  className="w-full rounded-xl border border-slate-700 bg-slate-950/60 px-4 py-3 text-base text-white shadow focus-visible:border-primary focus-visible:ring-4 focus-visible:ring-primary/40"
+                />
+              </label>
+              {error && <p className="text-sm text-rose-400" role="alert">{error}</p>}
+
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <Toggle value={system} onChange={handleSystemChange} />
+                <p className="text-xs text-slate-400">
+                  Auto-detected: <span className="font-semibold text-slate-200">{detectedLabel}</span>
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                <button
+                  type="submit"
+                  className="w-full rounded-xl bg-primary px-6 py-3 text-base font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 sm:w-auto"
+                >
+                  Convert
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  disabled={!result}
+                  className="w-full rounded-xl border border-slate-700 bg-slate-900 px-6 py-3 text-base font-semibold text-slate-200 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:border-slate-800 disabled:bg-slate-900 disabled:text-slate-500 sm:w-auto"
+                >
+                  Copy result
+                </button>
+              </div>
+            </form>
+          </section>
+
+          <section className="relative rounded-3xl bg-slate-900/40 p-6 ring-1 ring-slate-800/60 backdrop-blur">
+            <h2 className="text-lg font-semibold text-slate-200">Result</h2>
+            <p className="mt-2 text-sm text-slate-400">Output is announced for assistive technologies and updates instantly after conversion.</p>
+            <div
+              aria-live="polite"
+              className="mt-6 min-h-[5rem] rounded-2xl border border-dashed border-slate-700 bg-slate-950/30 p-6 text-lg text-white"
+            >
+              {result || <span className="text-slate-500">Your conversion will appear here.</span>}
+            </div>
+          </section>
+        </main>
+      </div>
+      <Toast message={toastMessage} visible={toastVisible} onDismiss={hideToast} />
+    </div>
+  );
+};
+
+export default App;

--- a/number-to-text/src/components/Toast.tsx
+++ b/number-to-text/src/components/Toast.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { clsx } from 'clsx';
+
+type ToastProps = {
+  message: string;
+  visible: boolean;
+  onDismiss: () => void;
+  duration?: number;
+};
+
+const Toast = ({ message, visible, onDismiss, duration = 2000 }: ToastProps) => {
+  useEffect(() => {
+    if (!visible) return;
+    const timeout = window.setTimeout(onDismiss, duration);
+    return () => window.clearTimeout(timeout);
+  }, [visible, onDismiss, duration]);
+
+  return (
+    <div
+      aria-live="polite"
+      className={clsx(
+        'pointer-events-none fixed inset-x-0 top-4 flex justify-center transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      <div className="pointer-events-auto rounded-full bg-slate-800/90 px-4 py-2 text-sm text-white shadow-lg">
+        {message}
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/number-to-text/src/components/Toggle.tsx
+++ b/number-to-text/src/components/Toggle.tsx
@@ -1,0 +1,49 @@
+import { useId } from 'react';
+import { NumberingSystem } from '../lib/helpers';
+import { clsx } from 'clsx';
+
+type ToggleProps = {
+  value: NumberingSystem;
+  onChange: (value: NumberingSystem) => void;
+};
+
+const Toggle = ({ value, onChange }: ToggleProps) => {
+  const id = useId();
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium text-slate-200">Numbering system</legend>
+      <div className="inline-flex rounded-full bg-slate-800 p-1 shadow-inner" role="radiogroup" aria-labelledby={id}>
+        <span id={id} className="sr-only">
+          Select numbering system
+        </span>
+        {(
+          [
+            { label: 'International', value: 'international' },
+            { label: 'Indian', value: 'indian' }
+          ] satisfies { label: string; value: NumberingSystem }[]
+        ).map((option) => {
+          const isActive = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              onClick={() => onChange(option.value)}
+              className={clsx(
+                'px-4 py-2 text-sm font-medium rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary focus-visible:ring-offset-slate-900',
+                isActive
+                  ? 'bg-primary text-white shadow'
+                  : 'bg-transparent text-slate-300 hover:text-white hover:bg-slate-700'
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};
+
+export default Toggle;

--- a/number-to-text/src/lib/converter.test.ts
+++ b/number-to-text/src/lib/converter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { convertNumberToText } from './converter';
+
+describe('convertNumberToText', () => {
+  it('converts zero', () => {
+    expect(convertNumberToText(0, 'international')).toBe('Zero');
+    expect(convertNumberToText(0, 'indian')).toBe('Zero');
+  });
+
+  it('converts small numbers', () => {
+    expect(convertNumberToText(21, 'international')).toBe('Twenty one');
+    expect(convertNumberToText(21, 'indian')).toBe('Twenty one');
+  });
+
+  it('converts hundreds without conjunctions', () => {
+    expect(convertNumberToText(105, 'international')).toBe('One hundred five');
+  });
+
+  it('converts using the international system', () => {
+    expect(convertNumberToText(12_345_678, 'international')).toBe(
+      'Twelve million three hundred forty five thousand six hundred seventy eight'
+    );
+  });
+
+  it('converts using the indian system', () => {
+    expect(convertNumberToText(12_345_678, 'indian')).toBe(
+      'One crore twenty three lakh forty five thousand six hundred seventy eight'
+    );
+  });
+
+  it('handles maximum supported value', () => {
+    expect(convertNumberToText(9_999_999_999, 'international')).toBe(
+      'Nine billion nine hundred ninety nine million nine hundred ninety nine thousand nine hundred ninety nine'
+    );
+    expect(convertNumberToText(9_999_999_999, 'indian')).toBe(
+      'Nine hundred ninety nine crore ninety nine lakh ninety nine thousand nine hundred ninety nine'
+    );
+  });
+
+  it('throws on invalid numbers', () => {
+    expect(() => convertNumberToText(-1, 'international')).toThrow();
+  });
+});

--- a/number-to-text/src/lib/converter.ts
+++ b/number-to-text/src/lib/converter.ts
@@ -1,0 +1,122 @@
+import { NumberingSystem, sentenceCase } from './helpers';
+
+const units = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen'
+];
+
+const tens = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety'
+];
+
+const internationalScales = [
+  { value: 1_000_000_000, label: 'billion' },
+  { value: 1_000_000, label: 'million' },
+  { value: 1_000, label: 'thousand' }
+] as const;
+
+const indianScales = [
+  { value: 10_000_000, label: 'crore' },
+  { value: 100_000, label: 'lakh' },
+  { value: 1_000, label: 'thousand' }
+] as const;
+
+const convertBelowThousand = (num: number): string => {
+  const result: string[] = [];
+  const hundreds = Math.floor(num / 100);
+  const remainder = num % 100;
+
+  if (hundreds > 0) {
+    result.push(`${units[hundreds]} hundred`);
+  }
+
+  if (remainder > 0) {
+    if (remainder < 20) {
+      result.push(units[remainder]);
+    } else {
+      const tenValue = Math.floor(remainder / 10);
+      const unit = remainder % 10;
+      if (tenValue > 0) {
+        result.push(unit > 0 ? `${tens[tenValue]} ${units[unit]}` : tens[tenValue]);
+      }
+    }
+  }
+
+  return result.join(' ').trim();
+};
+
+export const convertNumberToText = (num: number, system: NumberingSystem): string => {
+  if (!Number.isInteger(num) || num < 0) {
+    throw new Error('Only non-negative integers are supported.');
+  }
+  if (num === 0) {
+    return 'Zero';
+  }
+
+  if (system === 'international') {
+    if (num < 1000) {
+      return sentenceCase(convertBelowThousand(num));
+    }
+    const parts: string[] = [];
+    let remainder = num;
+    for (const { value, label } of internationalScales) {
+      if (remainder >= value) {
+        const chunk = Math.floor(remainder / value);
+        remainder %= value;
+        parts.push(`${convertNumberToText(chunk, 'international').toLowerCase()} ${label}`);
+      }
+    }
+    if (remainder > 0) {
+      parts.push(convertBelowThousand(remainder));
+    }
+    return sentenceCase(parts.join(' ').replace(/\s+/g, ' ').trim());
+  }
+
+  // Indian system
+  if (num < 1000) {
+    return sentenceCase(convertBelowThousand(num));
+  }
+
+  const parts: string[] = [];
+  let remainder = num;
+  for (const { value, label } of indianScales) {
+    if (remainder >= value) {
+      const chunk = Math.floor(remainder / value);
+      remainder %= value;
+      parts.push(`${convertNumberToText(chunk, 'indian').toLowerCase()} ${label}`);
+    }
+  }
+
+  if (remainder > 0) {
+    parts.push(convertBelowThousand(remainder));
+  }
+
+  return sentenceCase(parts.join(' ').replace(/\s+/g, ' ').trim());
+};

--- a/number-to-text/src/lib/helpers.ts
+++ b/number-to-text/src/lib/helpers.ts
@@ -1,0 +1,42 @@
+export const MAX_VALUE = 9_999_999_999;
+
+export type NumberingSystem = 'international' | 'indian';
+
+export const sentenceCase = (value: string): string => {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+};
+
+export const sanitizeNumericInput = (value: string): string => value.replace(/,/g, '');
+
+export const isValidDigitsOnly = (value: string): boolean => /^[0-9]+$/.test(value);
+
+export const detectSystemFromLocale = (locale?: string): NumberingSystem => {
+  const language = (locale ?? '').toLowerCase();
+  if (language.includes('-in') || language.endsWith('in')) {
+    return 'indian';
+  }
+  return 'international';
+};
+
+export const loadPersistedSystem = (): NumberingSystem | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem('number-to-text:system');
+    if (stored === 'international' || stored === 'indian') {
+      return stored;
+    }
+  } catch (error) {
+    console.warn('Unable to read stored numbering system', error);
+  }
+  return null;
+};
+
+export const persistSystem = (system: NumberingSystem): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem('number-to-text:system', system);
+  } catch (error) {
+    console.warn('Unable to persist numbering system', error);
+  }
+};

--- a/number-to-text/src/main.tsx
+++ b/number-to-text/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/number-to-text/src/styles.css
+++ b/number-to-text/src/styles.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid theme('colors.primary');
+  outline-offset: 2px;
+}

--- a/number-to-text/tailwind.config.js
+++ b/number-to-text/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#2B59C3',
+        accent: '#F2A104',
+        surface: '#F8FAFC',
+        border: '#CBD5F5'
+      }
+    }
+  },
+  plugins: []
+};

--- a/number-to-text/tsconfig.json
+++ b/number-to-text/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/number-to-text/tsconfig.node.json
+++ b/number-to-text/tsconfig.node.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts", "src"]
+}

--- a/number-to-text/vite.config.ts
+++ b/number-to-text/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov']
+    }
+  }
+});

--- a/number-to-text/vitest.setup.ts
+++ b/number-to-text/vitest.setup.ts
@@ -1,0 +1,1 @@
+// Custom setup for Vitest can go here.


### PR DESCRIPTION
## Summary
- scaffold a Vite + React TypeScript app for converting numbers to text with Tailwind styling
- implement locale-aware international and Indian numbering logic with validation and clipboard support
- add unit and integration tests for conversion accuracy and core UI behaviour

## Testing
- `npm install` *(fails: 403 Forbidden fetching scoped packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908b3bf67a8832196fab1a4d9012d6b